### PR TITLE
Update readme.md

### DIFF
--- a/Solutions/Microsoft Entra ID/Playbooks/Reset-AADUserPassword/readme.md
+++ b/Solutions/Microsoft Entra ID/Playbooks/Reset-AADUserPassword/readme.md
@@ -56,6 +56,86 @@ Add-AzureADDirectoryRoleMember -ObjectId $role.ObjectId -RefObjectId $MI.ObjectI
 New-AzRoleAssignment -ObjectId $MIGuid -RoleDefinitionName $SentinelRoleName -Scope /subscriptions/$SubscriptionId/resourcegroups/$ResourceGroupName
 ```
 
+- Utilize Microsoft Graph PowerShell to assign Entra roles. You may assign Azure roles on the "Identity" blade under "Settings" for the Logic App.<br>
+ Run the following code after replacing the Logic App and Resource Group name.
+```powershell
+$directoryRoleName = 'Password Administrator'
+$logicAppName = '<Enter your logic app name here>'
+$resourceGroupName = '<Enter your resource group name here>'
+$resourceType = 'Microsoft.Logic/workflows'
+
+# Look up the logic app's managed identity's object ID.
+$managedIdentityObjectId = (Get-AzResource -ResourceGroupName $resourceGroupName -Name $logicAppName -ResourceType $resourceType).Identity.PrincipalId
+$odataId = 'https://graph.microsoft.com/v1.0/directoryObjects/' + $managedIdentityObjectId
+
+try {
+    # Find the specific role by name
+    $directoryRoleTemplate = Get-MgDirectoryRoleTemplate | Where-Object { $_.DisplayName -eq $directoryRoleName }
+    $directoryRoleTemplateId = $directoryRoleTemplate.Id
+
+    # Attempt to get the directory role
+    $role = Get-MgDirectoryRoleByRoleTemplateId -RoleTemplateId $directoryRoleTemplateId -ErrorAction Stop
+    Write-Host('The ' + $role.DisplayName + ' role is activated.')
+}
+catch {
+    $errorDetails = $_
+    $errorException = $errorDetails.Exception
+    $errorMessage = $errorDetails.Exception.Message
+    $errorId = $errorDetails.FullyQualifiedErrorId
+
+    # Check for specific status codes and handle accordingly
+    if ($errorId -eq 'Request_ResourceNotFound,Microsoft.Graph.PowerShell.Cmdlets.GetMgDirectoryRoleByRoleTemplateId_Get') {
+        Write-Host $errorMessage
+        Write-Host 'Activating the role ...'
+        New-MgDirectoryRole -RoleTemplateId $directoryRoleTemplateId -Confirm
+        Write-Host('The ' + $role.DisplayName + ' role is activated.')
+    }
+    else {
+        # Handle other errors
+        Write-Host $errorException
+    }
+}
+
+try {
+    # Use the constructed OdataId directly in the cmdlet
+    New-MgDirectoryRoleMemberByRef -DirectoryRoleId $role.Id -OdataId $odataId -Confirm -ErrorAction Stop
+}
+catch {
+    $errorDetails = $_
+    $errorException = $errorDetails.Exception
+    $errorMessage = $errorDetails.Exception.Message
+    $errorId = $errorDetails.FullyQualifiedErrorId
+
+    # Check for specific status codes and handle accordingly
+    if ($errorId -eq 'Request_BadRequest,Microsoft.Graph.PowerShell.Cmdlets.NewMgDirectoryRoleMemberByRef_CreateExpanded') {
+        Write-Host $errorMessage
+        Write-Host 'Checking the membership ...'
+    }
+    else {
+        # Handle other errors
+        Write-Host $errorException
+    }
+}
+
+# Retrieve the service principal
+$servicePrincipal = Get-MgServicePrincipal -ServicePrincipalId $managedIdentityObjectId
+
+if ($null -eq $servicePrincipal) {
+    Write-Host 'Service Principal with ID ' + $managedIdentityObjectId + ' not found.'
+} else {
+    # Output service principal details
+    Write-Host 'Service Principal found:'
+
+    # Retrieve memberOf relationships
+    $memberOf = Get-MgServicePrincipalMemberOf -ServicePrincipalId $servicePrincipal.Id
+    if ($memberOf) {
+        $servicePrincipal.DisplayName
+        $memberOf | Format-List
+    } else {
+        Write-Host('No memberships found for Service Principal with ID' + $($servicePrincipal.Id) + ' .')
+    }
+}
+```
 
 ## Screenshots
 **Incident Trigger**<br>


### PR DESCRIPTION
Provide an alternative to assign Entra roles to system assigned managed identity as Azure AD and MSOnline PowerShell modules are deprecated as of March 30, 2024.

https://learn.microsoft.com/en-us/powershell/azure/active-directory/overview?view=azureadps-2.0

   Required items, please complete
   
   Change(s):
   - Added Microsoft Graph Powershell alternatives to assign Entra roles to system assigned managed identity.

   Reason for Change(s):
   - Azure AD and MSOnline PowerShell modules are deprecated as of March 30, 2024.

   Version Updated:
   - No.

   Testing Completed:
   - It's tested locally.

   Checked that the validations are passing and have addressed any issues that are present:
   - No.